### PR TITLE
[#14] feat: 이용약관/개인정보 처리방침 상세보기 모달 추가

### DIFF
--- a/app/signup/components/fields/TermsDetailButton.tsx
+++ b/app/signup/components/fields/TermsDetailButton.tsx
@@ -1,0 +1,36 @@
+import useModal from "@/hooks/useModal";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+
+type TermsDetailButtonProps = {
+  title: string;
+  children: React.ReactNode;
+};
+
+export default function TermsDetailButton({ title, children }: TermsDetailButtonProps) {
+  const { open, handleOpenModal, handleCloseModal } = useModal();
+
+  return (
+    <>
+      <button type="button" onClick={handleOpenModal} className="text-text-secondary text-sm">
+        자세히 보기
+      </button>
+
+      {open && (
+        <Modal onClick={handleCloseModal}>
+          <h3 id="modal-title" className="mb-4 text-center text-2xl font-bold">
+            {title}
+          </h3>
+
+          <div className="mb-8 max-h-[60vh] overflow-y-auto rounded-[10px] border p-6 text-sm">
+            {children}
+          </div>
+
+          <Button varient="default" width="lg" height="md" fontSize="md" onClick={handleCloseModal}>
+            확인
+          </Button>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/app/signup/components/fields/TermsField.tsx
+++ b/app/signup/components/fields/TermsField.tsx
@@ -1,6 +1,6 @@
 import { FieldErrors, UseFormRegister } from "react-hook-form";
 import { SignupFormValues } from "@/app/signup/data/signup";
-import Checkbox from "@/components/ui/Checkbox";
+import TermsItem from "./TermsItem";
 
 type TermsFieldProps = {
   register: UseFormRegister<SignupFormValues>;
@@ -10,27 +10,41 @@ type TermsFieldProps = {
 export default function TermsField({ register, errors }: TermsFieldProps) {
   return (
     <div className="flex flex-col gap-2">
-      {/* 이용약관 */}
-      <div>
-        <Checkbox
-          label="이용약관에 동의합니다."
-          {...register("agreeTerms", { required: "이용 약관에 동의해야 합니다." })}
-        />
-        {errors.agreeTerms && <p className="text-danger text-sm">{errors.agreeTerms.message}</p>}
-      </div>
+      <TermsItem
+        name="agreeTerms"
+        label="이용약관에 동의합니다."
+        detailTitle="이용약관"
+        detailContent={
+          <div className="space-y-3 text-sm leading-relaxed">
+            <p>
+              <strong>제 1조 (목적)</strong>
+            </p>
+            <p>
+              본 약관은 서비스 이용과 관련하여 회사와 이용자의 권리, 의무를 규정함을 목적으로
+              합니다.
+            </p>
 
-      {/* 개인정보 */}
-      <div>
-        <Checkbox
-          label="개인정보 수집 및 이용에 동의합니다."
-          {...register("agreePrivacy", {
-            required: "개인정보 수집 및 이용에 동의해야 합니다.",
-          })}
-        />
-        {errors.agreePrivacy && (
-          <p className="text-danger text-sm">{errors.agreePrivacy.message}</p>
-        )}
-      </div>
+            <p>
+              <strong>제 2조 (정의)</strong>
+            </p>
+            <ul className="list-disc pl-5">
+              <li>“서비스”란 회사가 제공하는 웹 기반 서비스를 의미합니다.</li>
+              <li>“이용자”란 본 약관에 동의하고 서비스를 이용하는 자를 의미합니다.</li>
+            </ul>
+          </div>
+        }
+        register={register}
+        error={errors.agreeTerms}
+      />
+
+      <TermsItem
+        name="agreePrivacy"
+        label="개인정보 수집 및 이용에 동의합니다."
+        detailTitle="개인정보 수집 및 이용"
+        detailContent={<>여기에 개인정보 수집 및 이용 내용...</>}
+        register={register}
+        error={errors.agreePrivacy}
+      />
     </div>
   );
 }

--- a/app/signup/components/fields/TermsItem.tsx
+++ b/app/signup/components/fields/TermsItem.tsx
@@ -1,0 +1,56 @@
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+import { RiCheckLine } from "@remixicon/react";
+import clsx from "clsx";
+import TermsDetailButton from "./TermsDetailButton";
+import { SignupFormValues } from "@/app/signup/data/signup";
+
+type TermsItemProps = {
+  name: keyof Pick<SignupFormValues, "agreeTerms" | "agreePrivacy">;
+  label: string;
+  detailTitle: string;
+  detailContent: React.ReactNode;
+  error?: FieldErrors<SignupFormValues>[keyof Pick<
+    SignupFormValues,
+    "agreeTerms" | "agreePrivacy"
+  >];
+  register: UseFormRegister<SignupFormValues>;
+};
+
+export default function TermsItem({
+  name,
+  label,
+  detailTitle,
+  detailContent,
+  error,
+  register,
+}: TermsItemProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <label className="flex flex-1 cursor-pointer items-center gap-2">
+          <input
+            type="checkbox"
+            {...register(name, { required: `${detailTitle}에 동의해야 합니다.` })}
+            className="peer hidden"
+          />
+          <span
+            className={clsx(
+              "flex h-4 w-4 items-center justify-center rounded border",
+              "peer-checked:bg-main peer-checked:border-main",
+              "border-[#E0E0E0] bg-white"
+            )}
+          >
+            <RiCheckLine color="rgba(255,255,255,1)" size={14} />
+          </span>
+          {label}
+        </label>
+
+        <div className="shrink-0">
+          <TermsDetailButton title={detailTitle}>{detailContent}</TermsDetailButton>
+        </div>
+      </div>
+
+      {error && <p className="text-danger text-sm">{error.message}</p>}
+    </div>
+  );
+}

--- a/hooks/useModal.ts
+++ b/hooks/useModal.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 function useModal() {
-  const [open, setOpen] = useState<boolean>(true);
+  const [open, setOpen] = useState<boolean>(false);
 
   const handleOpenModal = () => {
     setOpen(true);


### PR DESCRIPTION
## 제목 
[#14] feat: 이용약관/개인정보 처리방침 상세보기 모달 추가

## 작업 내용
- 회원가입 폼 내 이용약관 / 개인정보 처리방침 자세히 보기 기능 추가
- 공통 Modal 컴포넌트를 활용해 약관 상세 내용을 모달로 표시하도록 구현
- 약관 UI를 재사용 가능하도록 컴포넌트 구조 분리
  - TermsItem
  - TermsDetailButton
- useModal 훅의 초기 open 값을 true → false로 변경

## 이슈 넘버
- #14